### PR TITLE
[✨ Feature/178] 해더 프로필 이름,이미지 api 연결

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { useQueryClient } from '@tanstack/react-query';
 import Image from 'next/image';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
@@ -14,6 +15,7 @@ import { validateEmail, validatePassword } from '@/util/validations';
 export default function LoginPage() {
   useGuestOnly();
 
+  const queryClient = useQueryClient();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
 
@@ -56,6 +58,9 @@ export default function LoginPage() {
       // 토큰 저장
       localStorage.setItem('accessToken', result.accessToken);
       localStorage.setItem('refreshToken', result.refreshToken);
+
+      // user 캐시 갱신
+      await queryClient.invalidateQueries({ queryKey: ['user'] });
 
       router.push('/');
     } catch (err) {

--- a/src/components/Header/HeaderAuth.tsx
+++ b/src/components/Header/HeaderAuth.tsx
@@ -8,12 +8,15 @@ import ProfileMenu from './ProfileMenu';
 
 import Notification from '@/components/Notification';
 import useClickOutside from '@/hooks/useClickOutside';
+import { useUser } from '@/hooks/useUser';
 import { logout } from '@/util/logout';
 
 export default function HeaderAuth() {
   const [isOpen, setIsOpen] = useState(false);
   const profileRef = useClickOutside(() => setIsOpen(false));
   const router = useRouter();
+  const { user } = useUser();
+
   const handleLogout = () => {
     logout();
     router.push('/login');
@@ -25,7 +28,8 @@ export default function HeaderAuth() {
       <span className="text-[17px] leading-[30px] text-gray-100">|</span>
       <div className="relative" ref={profileRef}>
         <ProfileButton
-          name="홍길동"
+          name={user?.nickname}
+          url={user?.profileImageUrl}
           onClick={() => setIsOpen((prev) => !prev)}
         />
 

--- a/src/components/Header/ProfileButton.tsx
+++ b/src/components/Header/ProfileButton.tsx
@@ -1,18 +1,23 @@
 import Profile from '@/components/Profile';
 
 interface ProfileButtonProps {
-  name: string;
+  name: string | undefined;
+  url: string | undefined;
   onClick: () => void;
 }
 
-export default function ProfileButton({ name, onClick }: ProfileButtonProps) {
+export default function ProfileButton({
+  name,
+  url,
+  onClick,
+}: ProfileButtonProps) {
   return (
     <button
       type="button"
       onClick={onClick}
       className="flex cursor-pointer items-center gap-2"
       aria-haspopup="menu">
-      <Profile size="sm"></Profile>
+      <Profile size="sm" src={url}></Profile>
       <span className="text-sm text-gray-950">{name}</span>
     </button>
   );

--- a/src/components/Profile.tsx
+++ b/src/components/Profile.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @next/next/no-img-element */
 'use client';
 
 import { cva } from 'class-variance-authority';
@@ -34,11 +35,10 @@ export default function Profile({
 }: ProfileProps) {
   return (
     <div className={cn(profileVariants({ size }), className, 'relative')}>
-      <Image
-        src={src || defaultProfile}
+      <img
+        src={src || defaultProfile.src}
         alt={alt}
-        fill
-        className="rounded-full object-cover"
+        className="h-full w-full rounded-full object-cover object-center"
       />
     </div>
   );


### PR DESCRIPTION
<!-- PR 제목은 생성한 이슈와 동일하게 작성해 주세요. -->
<!-- ex) [✨ Feature/이슈 번호] 로그인 페이지 UI 구현 -->

## ✅ PR 체크리스트

- [x] 기능 정상 동작
- [x] 콘솔 에러 없음
- [x] UI 동작 및 반응형 레이아웃 확인

## 🔗 이슈 번호

<!-- PR과 연관된 이슈 번호를 작성해 주세요. ex) #1 -->
<!-- 이슈가 해결되지 않은 상태로 PR을 업로드한다면 close를 지워주세요. -->

- close #178 

## ✨ 작업한 내용
- Header 프로필 영역 이름,프로필 이미지 API 데이터 연동하였습니다. 
- svg 파일 선대응 하여 Image에서 img 태그로 변경하였습니다. 

### 프로필이미지 등록후
<img width="430" height="82" alt="image" src="https://github.com/user-attachments/assets/d383a16b-e58f-4975-a265-057c9b49d45d" />

### 프로필 이미지 등록전
<img width="431" height="73" alt="image" src="https://github.com/user-attachments/assets/165b8c3c-b69a-4d26-806d-214b387561f0" />


<!-- 작업한 내용을 작성해 주세요 .-->
<!-- 프리뷰 링크로 확인 어려운 컴포넌트라면 스크린샷을 추가해주세요.-->

## 💁 리뷰 요청 / 코멘트

<!-- 코드리뷰가 필요한 부분이 있다면 작성해 주세요. -->

## 💡 참고사항

<!-- 추가로 작성할 내용이 있다면 작성해 주세요. -->
