### PR TITLE
[♻️ Refactor/182] 내 정보 타입 auth.ts의 UserResponse 타입 재사용

### DIFF
--- a/src/api/users.ts
+++ b/src/api/users.ts
@@ -1,17 +1,6 @@
-import { SignupRequest, SignupResponse } from '../types/auth';
+import { SignupRequest, SignupResponse, UserResponse } from '../types/auth';
 
 import { apiFetch } from '@/config/client';
-import { ResponseGetUsersMe } from '@/types/users';
-
-// 사용자 정보 타입
-export interface User {
-  id: number;
-  email: string;
-  nickname: string;
-  profileImageUrl: string;
-  createdAt: string;
-  updatedAt: string;
-}
 
 // 사용자 정보 수정 요청 타입
 export interface UpdateUserRequest {
@@ -22,7 +11,7 @@ export interface UpdateUserRequest {
 
 // 내 정보 조회 - GET /{teamId}/users/me
 export const getUsersMe = async () => {
-  return apiFetch<ResponseGetUsersMe>('/users/me');
+  return apiFetch<UserResponse>('/users/me');
 };
 
 // 회원가입 - POST /{teamId}/users
@@ -34,10 +23,8 @@ export function signup(payload: SignupRequest) {
 }
 
 // 내 정보 수정
-export async function updateMe(
-  body: UpdateUserRequest
-): Promise<ResponseGetUsersMe> {
-  return apiFetch<ResponseGetUsersMe>('/users/me', {
+export async function updateMe(body: UpdateUserRequest): Promise<UserResponse> {
+  return apiFetch<UserResponse>('/users/me', {
     method: 'PATCH',
     body,
   });


### PR DESCRIPTION
<!-- PR 제목은 생성한 이슈와 동일하게 작성해 주세요. -->
<!-- ex) [✨ Feature/이슈 번호] 로그인 페이지 UI 구현 -->

## ✅ PR 체크리스트

- [x] 기능 정상 동작
- [x] 콘솔 에러 없음
- [x] UI 동작 및 반응형 레이아웃 확인

## 🔗 이슈 번호

<!-- PR과 연관된 이슈 번호를 작성해 주세요. ex) #1 -->
<!-- 이슈가 해결되지 않은 상태로 PR을 업로드한다면 close를 지워주세요. -->

- close #182 

## ✨ 작업한 내용

<!-- 작업한 내용을 작성해 주세요 .-->
<!-- 프리뷰 링크로 확인 어려운 컴포넌트라면 스크린샷을 추가해주세요.-->
- 내 정보(My Info) 관련 API 응답 타입을 auth.ts의 UserResponse 타입으로 통합
중복으로 정의되어 있던 사용자 타입 제거 및 공용 타입 재사용 구조로 리팩토링

## 💁 리뷰 요청 / 코멘트

<!-- 코드리뷰가 필요한 부분이 있다면 작성해 주세요. -->

## 💡 참고사항

<!-- 추가로 작성할 내용이 있다면 작성해 주세요. -->
