### PR TITLE
[🐛 Fix/190] 내 정보 콘텐츠 영역 전체 여백 제거

### DIFF
--- a/src/app/(common)/(mypage)/mypage/page.tsx
+++ b/src/app/(common)/(mypage)/mypage/page.tsx
@@ -34,16 +34,16 @@ export default function MyPage() {
   // 초기 데이터 로딩 중
   if (isInitialLoading) {
     return (
-      <section className="mx-auto max-w-2xl px-4 py-8">
+      <section>
         <LoadingSpinner />
       </section>
     );
   }
 
   return (
-    <section className="mx-auto max-w-2xl px-4 py-8">
+    <section>
       {/* 페이지 헤더 */}
-      <header className="mb-8">
+      <header>
         <PageHeader
           title="내 정보"
           description="닉네임과 비밀번호를 수정하실 수 있습니다."


### PR DESCRIPTION
<!-- PR 제목은 생성한 이슈와 동일하게 작성해 주세요. -->
<!-- ex) [✨ Feature/이슈 번호] 로그인 페이지 UI 구현 -->

## ✅ PR 체크리스트

- [x] 기능 정상 동작
- [x] 콘솔 에러 없음
- [x] UI 동작 및 반응형 레이아웃 확인

## 🔗 이슈 번호

<!-- PR과 연관된 이슈 번호를 작성해 주세요. ex) #1 -->
<!-- 이슈가 해결되지 않은 상태로 PR을 업로드한다면 close를 지워주세요. -->

- close #190 

## ✨ 작업한 내용

<!-- 작업한 내용을 작성해 주세요 .-->
<!-- 프리뷰 링크로 확인 어려운 컴포넌트라면 스크린샷을 추가해주세요.-->

- 내 정보(My Info) 페이지 콘텐츠 영역의 불필요한 padding 제거
- 다른 마이페이지의 메뉴 콘텐츠 시작점 동일하게 수정

## 💁 리뷰 요청 / 코멘트

<!-- 코드리뷰가 필요한 부분이 있다면 작성해 주세요. -->

## 💡 참고사항

<!-- 추가로 작성할 내용이 있다면 작성해 주세요. -->
