### PR TITLE
[♻️ Refactor] 로그인 회원가입 특정 알림 팝업사용으로 교체

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -9,16 +9,23 @@ import { login } from '@/api/auth';
 import kakaoLogo from '@/assets/icons/auth/ic-kakao.svg';
 import Button from '@/components/Button';
 import { TextInput, PasswordInput } from '@/components/Input';
+import BasicModal from '@/components/modal/BasicModal';
+import { useToast } from '@/components/toast/useToast';
 import { KAKAO_REST_API_KEY, KAKAO_REDIRECT_URI } from '@/config/oauth';
 import { useGuestOnly } from '@/hooks/useGuestOnly';
+import { useModal } from '@/hooks/useModal';
+import { getApiErrorMessage } from '@/util/error';
 import { validateEmail, validatePassword } from '@/util/validations';
 
 export default function LoginPage() {
   useGuestOnly();
 
   const queryClient = useQueryClient();
+  const { openModal, closeModal } = useModal();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const router = useRouter();
+  const toast = useToast();
 
   const handleKakaoLogin = () => {
     const url =
@@ -44,8 +51,6 @@ export default function LoginPage() {
     email: '',
     password: '',
   });
-
-  const router = useRouter();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -73,11 +78,30 @@ export default function LoginPage() {
 
       router.push('/');
     } catch (err) {
-      if (err instanceof Error) {
-        setErrors({
-          email: '',
-          password: err.message,
+      const errorMessage = getApiErrorMessage(
+        err,
+        '로그인 중 오류가 발생했습니다.'
+      );
+      // 비밀번호 불일치 케이스만 모달팝업으로 표현
+      if (errorMessage.includes('비밀번호가 일치하지 않습니다')) {
+        openModal({
+          component: BasicModal,
+          props: {
+            message: '비밀번호가 일치하지 않습니다',
+            buttonText: '확인',
+            onClick: () => closeModal(BasicModal),
+          },
         });
+        // 에러 상태 초기화
+        setErrors({ email: '', password: '' });
+      } else if (
+        errorMessage.includes('존재하지 않는') ||
+        errorMessage.includes('찾을 수 없') ||
+        errorMessage.includes('not found')
+      ) {
+        toast.error('등록되지 않은 이메일입니다');
+      } else {
+        toast.error('로그인에 실패했습니다. 다시 시도해 주세요.');
       }
     }
   };


### PR DESCRIPTION
<!-- PR 제목은 생성한 이슈와 동일하게 작성해 주세요. -->
<!-- ex) [✨ Feature/이슈 번호] 로그인 페이지 UI 구현 -->

## ✅ PR 체크리스트

- [x] 기능 정상 동작
- [x] 콘솔 에러 없음
- [x] UI 동작 및 반응형 레이아웃 확인

## 🔗 이슈 번호

<!-- PR과 연관된 이슈 번호를 작성해 주세요. ex) #1 -->
<!-- 이슈가 해결되지 않은 상태로 PR을 업로드한다면 close를 지워주세요. -->

- close #213

## ✨ 작업한 내용
♻️ Refactor: 회원가입, 로그인 에러메세지 처리 방식 정리

<!-- 작업한 내용을 작성해 주세요 .-->
<!-- 프리뷰 링크로 확인 어려운 컴포넌트라면 스크린샷을 추가해주세요.-->

## 💁 리뷰 요청 / 코멘트

이미 사용중인 이메일, 비밀번호 일치하지 않을때 두 케이스만 모달 베이직 팝업 적용
인풋 검사는 바로 아래 빨간 글자로 표현,
이외 알림은 토스트 팝업으로 정리

<img width="3840" height="2534" alt="image" src="https://github.com/user-attachments/assets/79004f76-4310-4efd-ae34-463eedd0394b" />
<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/768bac9d-5a48-4722-92e3-b0b5d50faf90" />


## 💡 참고사항

<!-- 추가로 작성할 내용이 있다면 작성해 주세요. -->
